### PR TITLE
Add Android 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Hooks the decryption function in `libnative.so` of ウマ娘プリティーダ�
 
 ## Usage
 
-Currently this only supports Android >= 8.0.
+Currently this only supports Android >= 8.0 and Android 6.
 
 1. Install [Magisk](https://github.com/topjohnwu/Magisk) and [Riru](https://github.com/RikkaApps/Riru).
 2. Install Riru-CarrotJuicer and reboot.

--- a/module.gradle
+++ b/module.gradle
@@ -7,7 +7,7 @@ ext {
     moduleName = "CarrotJuicer"
     moduleAuthor = "CNA-Bld"
     moduleDescription = "Juice the carrots from Umamusume Pretty Derby."
-    moduleVersion = "v1.0.1"
+    moduleVersion = "v1.0.2"
     moduleVersionCode = 1
 
     moduleProp = [


### PR DESCRIPTION
Android 6 does not have "__loader_dlopen" in libdl.so. Using "dlopen" would work.